### PR TITLE
Fixed bug in multi-gpu execution

### DIFF
--- a/vlp/run_img2txt_dist.py
+++ b/vlp/run_img2txt_dist.py
@@ -539,7 +539,7 @@ def main():
                 if n_gpu > 1:    # mean() to average on multi-gpu. For dist, this is done through gradient addition.
                     masked_lm_loss = masked_lm_loss.mean()
                     pretext_loss_deprecated = pretext_loss_deprecated.mean()
-                    vqa2_loss = ans_loss.mean()
+                    ans_loss = ans_loss.mean()
                 loss = masked_lm_loss + pretext_loss_deprecated + ans_loss
 
                 # logging for each step (i.e., before normalization by args.gradient_accumulation_steps)


### PR DESCRIPTION
Hi,

I just spotted a bug in the training script `run_img2txt_dist.py`. Specifically, when running the code with multiple GPUs the following exception is raised: 

```
Traceback (most recent call last):                                                                                                                                                
  File "vlp/run_guesswhat_dist.py", line 625, in <module>
    main()
  File "vlp/run_guesswhat_dist.py", line 543, in main
    vqa2_loss.append(ans_loss.item())
AttributeError: 'Tensor' object has no attribute 'append'
```

Unfortunately, this is due to the fact that at line https://github.com/LuoweiZhou/VLP/blob/master/vlp/run_img2txt_dist.py#L542 you're overriding `vqa2_loss` which will become a `torch.Tensor` therefore the `append` call at line 543 will break. 

This pull request fixes this error.
 